### PR TITLE
Parsing and Fallback

### DIFF
--- a/Crafter's db shit/map/dbsetmap.gotmpl
+++ b/Crafter's db shit/map/dbsetmap.gotmpl
@@ -3,7 +3,6 @@
 	Trigger Type: Command
 
 	Usage:
-	YOU HAVE TO INPUT THE CODE YOU WANT TO SAVE ON THE DASHBOARD INTO $v!!!!!
 	dbsetmap ID/Mention Key SdictName
 
 	Made by TheHDCrafter#0001
@@ -12,26 +11,35 @@
 {{$perms := "Administrator"}}
 {{/*The bot will check if the user has this permission.
 Permissions available: Administrator, ManageServer, ReadMessages, SendMessages, SendTTSMessages, ManageMessages, EmbedLinks, AttachFiles, ReadMessageHistory, MentionEveryone, VoiceConnect, VoiceSpeak, VoiceMuteMembers, VoiceDeafenMembers, VoiceMoveMembers, VoiceUseVAD, ManageNicknames, ManageRoles, ManageWebhooks, ManageEmojis, CreateInstantInvite, KickMembers, BanMembers, ManageChannels, AddReactions, ViewAuditLogs*/}}
-{{$v := `REPLACE THIS WITH THE SHIT YOU WANT TO SAVE`}}
-{{/*Replace the string above with anything you want to save*/}}
 
 
 {{if (in (split (index (split (exec "viewperms") "\n") 2) ", ") $perms)}}
 	{{$prefix := index (reFindAllSubmatches `Prefix of \x60\d+\x60: \x60(.+)\x60` (exec "prefix")) 0 1}}
-	{{$args := parseArgs 3 (print "Usage: " $prefix "dbsetmap <UserID> <Key> <sdictName>\nDashboard: <https://yagpdb.xyz/manage/" .Guild.ID "/customcommands/commands/" .CCID "/>\n**NOTE: YOU HAVE TO INPUT THE VALUE ON THE WEBSITE! USE THE LINK**")
+	{{$args := parseArgs 4 (print "Usage: " $prefix "dbsetmap <UserID> <Key> <sdictName> <sdictValue>")
 		(carg "userid" "UserID")
 		(carg "string" "Keyname")
-		(carg "string" "name")}}
+		(carg "string" "name")
+		(carg "string" "value")}}
 	{{$t1 := dbGet ($args.Get 0) ($args.Get 1)}}
 	{{$user := userArg ($args.Get 0)}}{{$userm := print "`" ($args.Get 0) "`"}}
 	{{with $user}}{{$userm = .Mention}}{{end}}
 	{{if $t1}}
-		{{$db := sdict $t1.Value}}
-		{{$db.Set ($args.Get 2) $v}}
-		{{dbSet ($args.Get 0) ($args.Get 1) $db}}
-		{{$embed := sdict "color" 0x00D66C "title" "✏️ created database map entry" "description" (print "<:checkmark:705738821425299527> Created `" ($args.Get 1) "` for " $userm " and saved it in `" ($args.Get 2) "`.")}}
-		{{if $user}}{{$embed.Set "thumbnail" (sdict "url" (print "https://cdn.discordapp.com/avatars/" ($args.Get 0) "/" $user.Avatar ".png?size=4096"))}}{{end}}
-		{{sendMessage nil (cembed $embed)}}
+        {{if eq (kindOf $t1.Value true) "map"}}
+            {{$val := $args.Get 3}}
+            {{if not (reFind `[^0-9.]+` ($args.Get 3))}}
+                {{$val = toFloat $val}}
+            {{else if not (reFind `[^0-9]+` ($args.Get 3))}}
+                {{$val = toInt $val}}
+            {{end}}
+            {{$db := sdict $t1.Value}}
+            {{$db.Set ($args.Get 2) $val}}
+            {{dbSet ($args.Get 0) ($args.Get 1) $db}}
+            {{$embed := sdict "color" 0x00D66C "title" "✏️ created database map entry" "description" (print "<:checkmark:705738821425299527> Created `" ($args.Get 1) "` for " $userm " and saved it in `" ($args.Get 2) "`.")}}
+            {{if $user}}{{$embed.Set "thumbnail" (sdict "url" (print "https://cdn.discordapp.com/avatars/" ($args.Get 0) "/" $user.Avatar ".png?size=4096"))}}{{end}}
+            {{sendMessage nil (cembed $embed)}}
+        {{else}}
+            {{sendMessage nil (cembed "color" 0xDD2E44 "title" "Something unexpected happened! :(" "description" "<:cross:705738821110595607> The type of the entry value is not a map!")}}
+        {{end}}
 	{{else}}
 		{{sendMessage nil (cembed "color" 0xDD2E44 "title" "Something unexpected happened! :(" "description" "<:cross:705738821110595607> This database entry doesn't exist!")}}
 	{{end}}


### PR DESCRIPTION
The changes allow for the value (`$v` which is now `$val`) to be entered as part of the command rather than having to go to the control panel each time a user wants to use it. With that change, it now parses integers and floats for the value. There is also now a fallback/error message for when a specified entry is not a `map[string]interface {}`.